### PR TITLE
Fixed smartbot logic to match the decision tree logic

### DIFF
--- a/bots/smartbot.cpp
+++ b/bots/smartbot.cpp
@@ -926,7 +926,7 @@ move smartbot::play_mystery(State s) {
 Just discard the oldest card in the hand.
 The oldest card is found at the leftmost position.
 */
-move smartbot::discard_old(State s) { // straightforward
+move smartbot::discard_old(State s) {
     int best_i = next_discard_index(s, id_);
     if (best_i != -1) {
         move m = move(DISCARD, id_, best_i);
@@ -1128,6 +1128,8 @@ move smartbot::give_valuable_warning(State s) { // check holmes for explanation
 
 /*
 Find the best hint to give for any partner.
+Here the best hint is defined as color or rank hint to any partner
+that provides the largest amount of information.
 */
 move smartbot::give_helpful_hint(State s) {
     if (s.get_num_hints() == 0) {
@@ -1209,11 +1211,11 @@ move smartbot::play(State s) {
         m = move(RANK_HINT, right_partner, id_, indices, s.get_hands()[right_partner][0].rank());
         return m;
     } else { // will need to discard
-        m = discard_old(s);
+        m = discard_worthless(s);
         if (m.get_type() != INVALID_MOVE) {
             return m;
         }
-        m = discard_worthless(s);
+        m = discard_old(s);
         if (m.get_type() != INVALID_MOVE) {
             return m;
         }


### PR DESCRIPTION
### Summary of changes
The purpose of this Pull Request is to fix the SmartBot logic to match the discard logic described in the decision tree, as shown in the picture below:
<img width="681" alt="Screenshot 2025-02-27 alle 22 21 41" src="https://github.com/user-attachments/assets/477fa85b-c057-401b-8775-6e8b8c9b7d57" />
Before, SmartBot attempted to discard an old card before discarding a worthless card, contrarily to what is described in the diagram. Now, SmartBot first attempts to discard a worthless card, and only if that choice is unsuccessful, it will discard an old card.
Note: a similar logic is implemented in HolmesBot here:
https://github.com/UofT-Hanabi-Lab/HanaSim/blob/da766467e08f34b80050200682bbf02f7ba199a7/bots/holmesbot.cpp#L529

___
### Testing checklist
<!-- You can check off the following items by adding an x between square brackets, like so [x] -->
I have tested my changes manually, since no unit tests have been set up yet.
